### PR TITLE
Adding cmake flag needed when compiling vicon_transformer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(vicon-datastream-sdk VERSION 1.11.0)
 
 set (CMAKE_CXX_STANDARD 11)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

When compiling `vicon_transformer`, I got the following error during linking.

```
/usr/bin/ld: /usr/local/lib/libViconDataStreamSDK_CPP.a(CoreClientTimingLog.cpp.o): relocation R_X86_64_TPOFF32 against symbol `_ZN5boost4asio6detail15keyword_tss_ptrINS1_10call_stackINS1_14thread_contextENS1_16thread_info_baseEE7contextEE6value_E' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
```

After setting `CMAKE_POSITION_INDEPENDENT_CODE` to `ON` when compiling `vicon-datastream-sdk` the error vanishes.

## How I Tested

[//]: # "Explain how you tested your changes"
Built and installed `vicon-datastream-sdk` and then compiled `vicon_transformer` via colcon.
